### PR TITLE
Make it possible to use ObjectIdentifier in BTreeMap

### DIFF
--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -188,7 +188,7 @@ impl Error for ObjectError {}
 
 /// Object identifier (type + instance number)
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ObjectIdentifier {
     pub object_type: ObjectType,
     pub instance: u32,

--- a/src/util/enum_macros.rs
+++ b/src/util/enum_macros.rs
@@ -78,7 +78,7 @@ macro_rules! generate_custom_enum {
         pastey::paste! {
             $(#[$doc])*
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
             pub enum $name {
                 $($variant,)*
                 Custom( [<$name Value>] ),
@@ -86,7 +86,7 @@ macro_rules! generate_custom_enum {
             }
 
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
             pub struct [<$name Value>] { value: $unit }
 
             impl [<$name Value>] {


### PR DESCRIPTION
Derive Ord and PartialOrd for ObjectIdentifier so it can be used as a key in a BTreeMap